### PR TITLE
update rubocop version

### DIFF
--- a/mnrbcop.gemspec
+++ b/mnrbcop.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   # rubocopのバージョンはここで管理
-  spec.add_dependency 'rubocop', '~> 0.53.0'
+  spec.add_dependency 'rubocop', '~> 0.59.2'
   spec.add_development_dependency "bundler", "~> 1.14"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"


### PR DESCRIPTION
* Rubyの2.6.xに対応してないので、0.5x.x系の最終バージョンまで引き上げ