### PR TITLE
Rubocopのバージョンを0.66まで引き上げ

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -415,8 +415,9 @@ Style/WordArray:
 
 # 0 <= foo && foo < 5 のように数直線上に並べるのは
 # コードを読みやすくするテクニックなので equality_operators_only に。
-Style/YodaCondition:
-  EnforcedStyle: equality_operators_only
+# TODO: rubocop 0.63.0以降はforbid_for_equality_operators_onlyなので依存を引き上げれば有効にできる
+#Style/YodaCondition:
+#  EnforcedStyle: equality_operators_only
 
 # 条件式で arr.size > 0 が使われた時に
 #   if !arr.empty?

--- a/mnrbcop.gemspec
+++ b/mnrbcop.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   # rubocopのバージョンはここで管理
-  spec.add_dependency 'rubocop', '~> 0.59.2'
+  spec.add_dependency 'rubocop', '~> 0.66'
   spec.add_development_dependency "bundler", "~> 1.14"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"


### PR DESCRIPTION
最新版のrubocopである 0.66 までバージョンを引き上げ
参考：https://github.com/rubocop-hq/rubocop/releases/tag/v0.66.0