### PR TITLE
Change 'EmptyLineAfterGuardClause' namespace to 'Layout'

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -23,6 +23,10 @@ Layout/ClassStructure:
 Layout/DotPosition:
   EnforcedStyle: trailing
 
+# ガード句と本質を分けるのは良いコードスタイルなので有効化
+Layout/EmptyLineAfterGuardClause:
+  Enabled: true
+
 # 桁揃えが綺麗にならないことが多いので migration は除外
 Layout/ExtraSpacing:
   Exclude:
@@ -250,10 +254,6 @@ Style/EmptyCaseCondition:
 # 明示的に else で nil を返すのは分かりやすいので許可する
 Style/EmptyElse:
   EnforcedStyle: empty
-
-# ガード句と本質を分けるのは良いコードスタイルなので有効化
-Style/EmptyLineAfterGuardClause:
-  Enabled: true
 
 # 空メソッドの場合だけ1行で書かなければいけない理由が無い
 # 「セミコロンは使わない」に寄せた方がルールがシンプル


### PR DESCRIPTION
### 概要
- `EmptyLineAfterGuardClause` の namespace変更対応

### 変更内容
- 下記のwaringが出ていたので対応
```
vendor/bundle/ruby/2.6.0/bundler/gems/mnrbcop-0b852d0a060b/config/rubocop.yml: Style/EmptyLineAfterGuardClause has the wrong namespace - should be Layout
```
- ref: https://github.com/rubocop-hq/rubocop/commit/1ab3c1d38bf31438d4ebc495136170384576f9b0#diff-c4a623a000731c5a177ec5b63a7af647