### PR TITLE
Update rubocop to 0.72.0

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -45,7 +45,7 @@ Layout/IndentFirstHashElement:
 
 # private/protected は一段深くインデントする
 Layout/IndentationConsistency:
-  EnforcedStyle: rails
+  EnforcedStyle: indented_internal_methods
 
 # メソッドチェーン感がより感じられるインデントにする
 Layout/MultilineMethodCallIndentation:

--- a/mnrbcop.gemspec
+++ b/mnrbcop.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   # rubocopのバージョンはここで管理
-  spec.add_dependency 'rubocop', '~> 0.66'
+  spec.add_dependency 'rubocop', '0.72'
   spec.add_development_dependency "bundler", "~> 1.14"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"


### PR DESCRIPTION
### 概要
- Update rubocop to 0.72.0

### 変更内容
- refs: https://github.com/rails/rails/issues/36584